### PR TITLE
feat:修复了配置的一些问题，加了一个新增广告的功能，加了统一的返回

### DIFF
--- a/src/main/java/com/tuan/controller/backend/AdvertismentController.java
+++ b/src/main/java/com/tuan/controller/backend/AdvertismentController.java
@@ -1,0 +1,39 @@
+package com.tuan.controller.backend;
+
+import com.tuan.dto.AdvertisementDTO;
+import com.tuan.response.Response;
+import com.tuan.response.ResponseCode;
+import com.tuan.service.IAdvertisementService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+
+
+/**
+ * Created by buzheng on 17/8/1.
+ */
+@RequestMapping("/ad/")
+@Controller
+public class AdvertismentController {
+
+    @Autowired
+    private IAdvertisementService iAdvertisementService;
+
+    @RequestMapping(value = "save.do")
+    @ResponseBody
+    public Response<Long> save(AdvertisementDTO advertisementDTO) {
+        Long result = 0L;
+        if (advertisementDTO == null) {
+            return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), ResponseCode.ILLEGAL_ARGUMENT.getDes(), result);
+        }
+        result = iAdvertisementService.addAdvertisement(advertisementDTO).getData();
+        if(result > 0){
+            return Response.success(result);
+        }
+        return Response.errorByFailed(result);
+    }
+}

--- a/src/main/java/com/tuan/dto/AdvertisementDTO.java
+++ b/src/main/java/com/tuan/dto/AdvertisementDTO.java
@@ -1,0 +1,10 @@
+package com.tuan.dto;
+
+import com.tuan.pojo.Advertisement;
+
+/**
+ * Created by buzheng on 17/7/31.
+ * 数据传输类
+ */
+public class AdvertisementDTO extends Advertisement {
+}

--- a/src/main/java/com/tuan/response/Response.java
+++ b/src/main/java/com/tuan/response/Response.java
@@ -1,0 +1,64 @@
+package com.tuan.response;
+
+/**
+ * Created by buzheng on 17/8/1.
+ * 通用返回类
+ */
+public class Response<T> {
+
+    private Integer code;
+    private String msg;
+    private T data;
+
+    private Response(Integer code, String msg, T data) {
+        this.code = code;
+        this.msg = msg;
+        this.data = data;
+    }
+
+    public Integer getCode() {
+        return code;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    /**
+     * 普通失败返回
+     *
+     * @param data
+     * @param <T>
+     * @return
+     */
+    public static <T> Response<T> errorByFailed(T data) {
+        return new Response(ResponseCode.FAILED.getCode(), ResponseCode.FAILED.getDes(), data);
+    }
+
+    /**
+     * 自定义返回类
+     * @param code
+     * @param msg
+     * @param data
+     * @param <T>
+     * @return
+     */
+    public static <T> Response<T> error(Integer code, String msg, T data) {
+        return new Response(code, msg, data);
+    }
+
+    /**
+     * 统一成功管理
+     *
+     * @param data
+     * @param <T>
+     * @return
+     */
+    public static <T> Response<T> success(T data) {
+        return new Response<T>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getDes(), data);
+    }
+}

--- a/src/main/java/com/tuan/response/ResponseCode.java
+++ b/src/main/java/com/tuan/response/ResponseCode.java
@@ -1,0 +1,51 @@
+package com.tuan.response;
+
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+/**
+ * Created by buzheng on 17/8/1.
+ * 统一的返回状态码
+ */
+@JsonSerialize
+public enum ResponseCode {
+
+    SUCCESS(1001, "SUCCESS"),
+    FAILED(1002, "FAILED"),
+    NEED_LOGIN(1003, "NEED_LOGIN"),
+    ILLEGAL_ARGUMENT(1004, "ILLEGAL_ARGUMENT");
+
+    private Integer code;
+    private String des;
+
+    ResponseCode(Integer code, String des) {
+        this.code = code;
+        this.des = des;
+    }
+
+    public Integer getCode() {
+        return code;
+    }
+
+    public void setCode(Integer code) {
+        this.code = code;
+    }
+
+    public String getDes() {
+        return des;
+    }
+
+    public void setDes(String des) {
+        this.des = des;
+    }
+
+    /**
+     * 判断是否是返回成功
+     *
+     * @return
+     */
+    @JsonIgnore
+    public boolean isSuccess() {
+        return code == 1001;
+    }
+}

--- a/src/main/java/com/tuan/service/IAdvertisementService.java
+++ b/src/main/java/com/tuan/service/IAdvertisementService.java
@@ -1,0 +1,18 @@
+package com.tuan.service;
+
+import com.tuan.dto.AdvertisementDTO;
+import com.tuan.response.Response;
+
+/**
+ * Created by buzheng on 17/7/31.
+ * 广告新增删除接口
+ */
+public interface IAdvertisementService {
+    /**
+     * 新增广告
+     *
+     * @param advertisementDTO
+     * @return
+     */
+    Response<Long> addAdvertisement(AdvertisementDTO advertisementDTO);
+}

--- a/src/main/java/com/tuan/service/impl/AdvertisementImpl.java
+++ b/src/main/java/com/tuan/service/impl/AdvertisementImpl.java
@@ -1,0 +1,46 @@
+package com.tuan.service.impl;
+
+import com.tuan.dao.AdvertisementMapper;
+import com.tuan.dto.AdvertisementDTO;
+import com.tuan.response.Response;
+import com.tuan.response.ResponseCode;
+import com.tuan.service.IAdvertisementService;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Created by buzheng on 17/7/31.
+ * 服务实现类
+ */
+@Service("iAdvertisementService")
+public class AdvertisementImpl implements IAdvertisementService {
+
+    @Autowired
+    private AdvertisementMapper advertisementMapper;
+
+    @Override
+    public Response<Long> addAdvertisement(AdvertisementDTO advertisementDTO) {
+        long result = 0L;
+        if (advertisementDTO == null) {
+            return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), ResponseCode.ILLEGAL_ARGUMENT.getDes(), result);
+        }
+        if (StringUtils.isBlank(advertisementDTO.getLink())) {
+            return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), "link cannot be empty", result);
+        }
+        if (StringUtils.isBlank(advertisementDTO.getTitle())) {
+            return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), "title cannot be empty", result);
+        }
+        if (StringUtils.isBlank(advertisementDTO.getImgFileName())) {
+            return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), "image file name cannot be empty", result);
+        }
+        if (advertisementDTO.getWeight() == null) {
+            return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), "weight cannot be empty", result);
+        }
+        result = advertisementMapper.insert(advertisementDTO);
+        if (result > 0) {
+            return Response.success(result);
+        }
+        return Response.errorByFailed(result);
+    }
+}

--- a/src/main/resources/applicationContext-datasource.xml
+++ b/src/main/resources/applicationContext-datasource.xml
@@ -77,7 +77,7 @@
     </bean>
 
     <bean name="mapperScannerConfigurer" class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-        <property name="basePackage" value="com.mmall.dao"/>
+        <property name="basePackage" value="com.tuan.dao"/>
     </bean>
 
     <!-- 使用@Transactional进行声明式事务管理需要声明下面这行 -->

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,9 @@
-<!DOCTYPE web-app PUBLIC
- "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
- "http://java.sun.com/dtd/web-app_2_3.dtd" >
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         id="WebApp_ID" version="2.5">
 
-<web-app>
   <display-name>Archetype Created Web Application</display-name>
   <filter>
     <filter-name>characterEncodingFilter</filter-name>


### PR DESCRIPTION
- 修复了配置的问题：因为扫描自动注入的时候，忘记扫描mapper导致mapper注入失败，但是log是报错在调用mapper的service里面的。
- 增加了统一的返回：考虑主要有两点，第一个是我不想让别人调用我的构造方法，不然比较难管理，不过我还是开了个口子，因为现在我还没办法完全想到所有的错误信息。第二是错误跟成功的我都写了，具体的返回类型是一个泛型，便于返回给前端不同的数据类型。
- 返回码：都用枚举管理，比较方便，定义一个code跟message，使用起来比较简洁。
- 调用http服务的时候，服务端返回406可以调试进去看看。
- 另外拦截的时候，最开始写的是拦截.do的请求，但是RequestMapping没写，导致错误。