### PR TITLE
增加条件查询广告

### DIFF
--- a/src/main/java/com/tuan/controller/backend/AdvertismentController.java
+++ b/src/main/java/com/tuan/controller/backend/AdvertismentController.java
@@ -1,6 +1,8 @@
 package com.tuan.controller.backend;
 
+import com.google.common.collect.Lists;
 import com.tuan.dto.AdvertisementDTO;
+import com.tuan.query.AdvertisementQuery;
 import com.tuan.response.Response;
 import com.tuan.response.ResponseCode;
 import com.tuan.service.IAdvertisementService;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.Resource;
+import java.util.List;
 
 
 /**
@@ -31,9 +34,20 @@ public class AdvertismentController {
             return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), ResponseCode.ILLEGAL_ARGUMENT.getDes(), result);
         }
         result = iAdvertisementService.addAdvertisement(advertisementDTO).getData();
-        if(result > 0){
+        if (result > 0) {
             return Response.success(result);
         }
         return Response.errorByFailed(result);
+    }
+
+    @RequestMapping("list.do")
+    @ResponseBody
+    public Response<List<AdvertisementDTO>> list(AdvertisementQuery advertisementQuery) {
+        List<AdvertisementDTO> result = Lists.newArrayList();
+        if (advertisementQuery == null) {
+            return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), ResponseCode.ILLEGAL_ARGUMENT.getDes(), result);
+        }
+        result = iAdvertisementService.selectListByQuery(advertisementQuery).getData();
+        return Response.success(result);
     }
 }

--- a/src/main/java/com/tuan/dao/AdvertisementMapper.java
+++ b/src/main/java/com/tuan/dao/AdvertisementMapper.java
@@ -1,6 +1,9 @@
 package com.tuan.dao;
 
 import com.tuan.pojo.Advertisement;
+import com.tuan.query.AdvertisementQuery;
+
+import java.util.List;
 
 public interface AdvertisementMapper {
     int deleteByPrimaryKey(Integer id);
@@ -14,4 +17,6 @@ public interface AdvertisementMapper {
     int updateByPrimaryKeySelective(Advertisement record);
 
     int updateByPrimaryKey(Advertisement record);
+
+    List<Advertisement> selectByQuery(AdvertisementQuery advertisementQuery);
 }

--- a/src/main/java/com/tuan/pojo/Advertisement.java
+++ b/src/main/java/com/tuan/pojo/Advertisement.java
@@ -1,5 +1,8 @@
 package com.tuan.pojo;
 
+import com.tuan.dto.AdvertisementDTO;
+import org.springframework.beans.BeanUtils;
+
 public class Advertisement {
     private Integer id;
 
@@ -61,5 +64,16 @@ public class Advertisement {
 
     public void setWeight(Integer weight) {
         this.weight = weight;
+    }
+
+    /**
+     * 将DO转化为DTO
+     * @param advertisement
+     * @return
+     */
+    public static AdvertisementDTO toDTO(Advertisement advertisement) {
+        AdvertisementDTO advertisementDTO = new AdvertisementDTO();
+        BeanUtils.copyProperties(advertisement, advertisementDTO);
+        return advertisementDTO;
     }
 }

--- a/src/main/java/com/tuan/query/AdvertisementQuery.java
+++ b/src/main/java/com/tuan/query/AdvertisementQuery.java
@@ -1,0 +1,50 @@
+package com.tuan.query;
+
+import javax.management.Query;
+
+/**
+ * Created by buzheng on 17/8/13.
+ * 广告查询类
+ */
+public class AdvertisementQuery extends Query {
+
+    private String title;
+
+    private String imgFileName;
+
+    private String link;
+
+    private Integer weight;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getImgFileName() {
+        return imgFileName;
+    }
+
+    public void setImgFileName(String imgFileName) {
+        this.imgFileName = imgFileName;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Integer weight) {
+        this.weight = weight;
+    }
+}

--- a/src/main/java/com/tuan/query/AdvertisementQuery.java
+++ b/src/main/java/com/tuan/query/AdvertisementQuery.java
@@ -6,7 +6,7 @@ import javax.management.Query;
  * Created by buzheng on 17/8/13.
  * 广告查询类
  */
-public class AdvertisementQuery extends Query {
+public class AdvertisementQuery extends BaseQuery {
 
     private String title;
 

--- a/src/main/java/com/tuan/query/BaseQuery.java
+++ b/src/main/java/com/tuan/query/BaseQuery.java
@@ -1,0 +1,20 @@
+package com.tuan.query;
+
+/**
+ * Created by buzheng on 17/8/13.
+ * 基础查询类
+ */
+public class BaseQuery {
+    /**
+     * 通过ID查询
+     */
+    private Integer id;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/tuan/service/IAdvertisementService.java
+++ b/src/main/java/com/tuan/service/IAdvertisementService.java
@@ -1,7 +1,10 @@
 package com.tuan.service;
 
 import com.tuan.dto.AdvertisementDTO;
+import com.tuan.query.AdvertisementQuery;
 import com.tuan.response.Response;
+
+import java.util.List;
 
 /**
  * Created by buzheng on 17/7/31.
@@ -15,4 +18,12 @@ public interface IAdvertisementService {
      * @return
      */
     Response<Long> addAdvertisement(AdvertisementDTO advertisementDTO);
+
+    /**
+     * 条件查询返回符合条件的列表
+     *
+     * @param advertisementQuery
+     * @return
+     */
+    Response<List<AdvertisementDTO>> selectListByQuery(AdvertisementQuery advertisementQuery);
 }

--- a/src/main/java/com/tuan/service/impl/AdvertisementImpl.java
+++ b/src/main/java/com/tuan/service/impl/AdvertisementImpl.java
@@ -1,8 +1,10 @@
 package com.tuan.service.impl;
 
+import com.google.common.collect.Lists;
 import com.tuan.dao.AdvertisementMapper;
 import com.tuan.dto.AdvertisementDTO;
 import com.tuan.pojo.Advertisement;
+import com.tuan.query.AdvertisementQuery;
 import com.tuan.response.Response;
 import com.tuan.response.ResponseCode;
 import com.tuan.service.IAdvertisementService;
@@ -10,6 +12,8 @@ import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * Created by buzheng on 17/7/31.
@@ -44,5 +48,20 @@ public class AdvertisementImpl implements IAdvertisementService {
             return Response.success(result);
         }
         return Response.errorByFailed(result);
+    }
+
+    @Override
+    public Response<List<AdvertisementDTO>> selectListByQuery(AdvertisementQuery advertisementQuery) {
+        List<AdvertisementDTO> result = Lists.newArrayList();
+        if (advertisementQuery == null) {
+            return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), ResponseCode.ILLEGAL_ARGUMENT.getDes(), result);
+        }
+        List<Advertisement> advertisements = advertisementMapper.selectByQuery(advertisementQuery);
+        if (advertisements != null) {
+            for (Advertisement advertisement : advertisements) {
+                result.add(Advertisement.toDTO(advertisement));
+            }
+        }
+        return Response.success(result);
     }
 }

--- a/src/main/resources/mappers/AdvertisementMapper.xml
+++ b/src/main/resources/mappers/AdvertisementMapper.xml
@@ -1,90 +1,90 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
-<mapper namespace="com.tuan.dao.AdvertisementMapper" >
-  <resultMap id="BaseResultMap" type="com.tuan.pojo.Advertisement" >
-    <constructor >
-      <idArg column="id" jdbcType="INTEGER" javaType="java.lang.Integer" />
-      <arg column="title" jdbcType="VARCHAR" javaType="java.lang.String" />
-      <arg column="img_file_name" jdbcType="VARCHAR" javaType="java.lang.String" />
-      <arg column="link" jdbcType="VARCHAR" javaType="java.lang.String" />
-      <arg column="weight" jdbcType="INTEGER" javaType="java.lang.Integer" />
-    </constructor>
-  </resultMap>
-  <sql id="Base_Column_List" >
+<mapper namespace="com.tuan.dao.AdvertisementMapper">
+    <resultMap id="BaseResultMap" type="com.tuan.pojo.Advertisement">
+        <constructor>
+            <idArg column="id" jdbcType="INTEGER" javaType="java.lang.Integer"/>
+            <arg column="title" jdbcType="VARCHAR" javaType="java.lang.String"/>
+            <arg column="img_file_name" jdbcType="VARCHAR" javaType="java.lang.String"/>
+            <arg column="link" jdbcType="VARCHAR" javaType="java.lang.String"/>
+            <arg column="weight" jdbcType="INTEGER" javaType="java.lang.Integer"/>
+        </constructor>
+    </resultMap>
+    <sql id="Base_Column_List">
     id, title, img_file_name, link, weight
   </sql>
-  <select id="selectByPrimaryKey" resultMap="BaseResultMap" parameterType="java.lang.Integer" >
-    select 
-    <include refid="Base_Column_List" />
-    from ad
-    where id = #{id,jdbcType=INTEGER}
-  </select>
-  <delete id="deleteByPrimaryKey" parameterType="java.lang.Integer" >
+    <select id="selectByPrimaryKey" resultMap="BaseResultMap" parameterType="java.lang.Integer">
+        select
+        <include refid="Base_Column_List"/>
+        from ad
+        where id = #{id,jdbcType=INTEGER}
+    </select>
+    <delete id="deleteByPrimaryKey" parameterType="java.lang.Integer">
     delete from ad
     where id = #{id,jdbcType=INTEGER}
   </delete>
-  <insert id="insert" parameterType="com.tuan.pojo.Advertisement" >
+    <insert id="insert" parameterType="com.tuan.pojo.Advertisement">
     insert into ad (id, title, img_file_name, 
       link, weight)
     values (#{id,jdbcType=INTEGER}, #{title,jdbcType=VARCHAR}, #{imgFileName,jdbcType=VARCHAR}, 
       #{link,jdbcType=VARCHAR}, #{weight,jdbcType=INTEGER})
   </insert>
-  <insert id="insertSelective" parameterType="com.tuan.pojo.Advertisement" >
-    insert into ad
-    <trim prefix="(" suffix=")" suffixOverrides="," >
-      <if test="id != null" >
-        id,
-      </if>
-      <if test="title != null" >
-        title,
-      </if>
-      <if test="imgFileName != null" >
-        img_file_name,
-      </if>
-      <if test="link != null" >
-        link,
-      </if>
-      <if test="weight != null" >
-        weight,
-      </if>
-    </trim>
-    <trim prefix="values (" suffix=")" suffixOverrides="," >
-      <if test="id != null" >
-        #{id,jdbcType=INTEGER},
-      </if>
-      <if test="title != null" >
-        #{title,jdbcType=VARCHAR},
-      </if>
-      <if test="imgFileName != null" >
-        #{imgFileName,jdbcType=VARCHAR},
-      </if>
-      <if test="link != null" >
-        #{link,jdbcType=VARCHAR},
-      </if>
-      <if test="weight != null" >
-        #{weight,jdbcType=INTEGER},
-      </if>
-    </trim>
-  </insert>
-  <update id="updateByPrimaryKeySelective" parameterType="com.tuan.pojo.Advertisement" >
-    update ad
-    <set >
-      <if test="title != null" >
-        title = #{title,jdbcType=VARCHAR},
-      </if>
-      <if test="imgFileName != null" >
-        img_file_name = #{imgFileName,jdbcType=VARCHAR},
-      </if>
-      <if test="link != null" >
-        link = #{link,jdbcType=VARCHAR},
-      </if>
-      <if test="weight != null" >
-        weight = #{weight,jdbcType=INTEGER},
-      </if>
-    </set>
-    where id = #{id,jdbcType=INTEGER}
-  </update>
-  <update id="updateByPrimaryKey" parameterType="com.tuan.pojo.Advertisement" >
+    <insert id="insertSelective" parameterType="com.tuan.pojo.Advertisement">
+        insert into ad
+        <trim prefix="(" suffix=")" suffixOverrides=",">
+            <if test="id != null">
+                id,
+            </if>
+            <if test="title != null">
+                title,
+            </if>
+            <if test="imgFileName != null">
+                img_file_name,
+            </if>
+            <if test="link != null">
+                link,
+            </if>
+            <if test="weight != null">
+                weight,
+            </if>
+        </trim>
+        <trim prefix="values (" suffix=")" suffixOverrides=",">
+            <if test="id != null">
+                #{id,jdbcType=INTEGER},
+            </if>
+            <if test="title != null">
+                #{title,jdbcType=VARCHAR},
+            </if>
+            <if test="imgFileName != null">
+                #{imgFileName,jdbcType=VARCHAR},
+            </if>
+            <if test="link != null">
+                #{link,jdbcType=VARCHAR},
+            </if>
+            <if test="weight != null">
+                #{weight,jdbcType=INTEGER},
+            </if>
+        </trim>
+    </insert>
+    <update id="updateByPrimaryKeySelective" parameterType="com.tuan.pojo.Advertisement">
+        update ad
+        <set>
+            <if test="title != null">
+                title = #{title,jdbcType=VARCHAR},
+            </if>
+            <if test="imgFileName != null">
+                img_file_name = #{imgFileName,jdbcType=VARCHAR},
+            </if>
+            <if test="link != null">
+                link = #{link,jdbcType=VARCHAR},
+            </if>
+            <if test="weight != null">
+                weight = #{weight,jdbcType=INTEGER},
+            </if>
+        </set>
+        where id = #{id,jdbcType=INTEGER}
+    </update>
+    <update id="updateByPrimaryKey" parameterType="com.tuan.pojo.Advertisement">
     update ad
     set title = #{title,jdbcType=VARCHAR},
       img_file_name = #{imgFileName,jdbcType=VARCHAR},
@@ -92,4 +92,23 @@
       weight = #{weight,jdbcType=INTEGER}
     where id = #{id,jdbcType=INTEGER}
   </update>
+    <select id="selectByQuery" parameterType="com.tuan.query.AdvertisementQuery" resultMap="BaseResultMap">
+        SELECT
+        <include refid="Base_Column_List"/>
+        FROM ad
+        WHERE
+        1=1
+        <if test="title != null">
+            and title = #{title,jdbcType=VARCHAR}
+        </if>
+        <if test="imgFileName != null">
+            and img_file_name = #{imgFileName,jdbcType=VARCHAR}
+        </if>
+        <if test="link != null">
+            and link = #{link,jdbcType=VARCHAR}
+        </if>
+        <if test="weight != null">
+            and weight = #{weight,jdbcType=INTEGER}
+        </if>
+    </select>
 </mapper>


### PR DESCRIPTION
1、为什么用BaseQuery
因为很多条件查询语句都是一样的，比如创建时间、创建者等等，继承自一个就比较好点。
2、不足
其实这里面应该再来个中转层的，不然数据库对象转后还要再转一遍为DTO就不是很友好了。
还没有实现分页查询。
说下自己想法：分页查询可以用工具，也可以自己实现一个序列化类，把自己查到第几条、第几页、有没有下一页做一个JSON对象返回给前端，前端查询的时候带上这些参数，我再反序列化就可以看到客户端想要什么信息了。
3、为什么SQL里面有1=1
因为害怕有些条件没传进来，没传就默认全部查吧