### PR TITLE
feat:完善自定义分页的回传参数

### DIFF
--- a/src/main/java/com/tuan/controller/backend/AdvertismentController.java
+++ b/src/main/java/com/tuan/controller/backend/AdvertismentController.java
@@ -47,8 +47,8 @@ public class AdvertismentController {
     public Response<List<AdvertisementDTO>> list(AdvertisementQuery advertisementQuery) {
         List<AdvertisementDTO> result = Lists.newArrayList();
         String mBook = "";
-        Integer page = 0;
-        Integer pageSize = 10;
+        Integer page = 1;
+        Integer pageSize = 1;
         if (advertisementQuery == null) {
             return Response.error(ResponseCode.ILLEGAL_ARGUMENT.getCode(), ResponseCode.ILLEGAL_ARGUMENT.getDes(), result);
         }
@@ -56,7 +56,7 @@ public class AdvertismentController {
             String extraMessage = advertisementQuery.getExtraMessage();
             AdvertisementParams advertisementParams = AdvertisementParams.covertToAdvertisementParams(extraMessage);
             page = advertisementParams.getPage();
-            pageSize = advertisementQuery.getPageSize();
+            pageSize = advertisementParams.getPageSize();
         }
         advertisementQuery.setPage(page);
         advertisementQuery.setPageSize(pageSize);

--- a/src/main/java/com/tuan/pagehelper/AdvertisementParams.java
+++ b/src/main/java/com/tuan/pagehelper/AdvertisementParams.java
@@ -3,9 +3,12 @@ package com.tuan.pagehelper;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.tuan.utils.JSONUtils;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.util.JSONPObject;
+
+import java.io.UnsupportedEncodingException;
 
 /**
  * Created by buzheng on 17/8/13.
@@ -20,7 +23,13 @@ public class AdvertisementParams extends BaseParams {
         if (pageSize != null) {
             obj.addProperty("pageSize", pageSize);
         }
-        return obj.toString();
+        byte[] encodeBase64Mbook = null;
+        try {
+            encodeBase64Mbook = Base64.encodeBase64(obj.toString().getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        return new String(encodeBase64Mbook);
     }
 
     public int getPage() {
@@ -31,6 +40,18 @@ public class AdvertisementParams extends BaseParams {
         return NumberUtils.toInt(parseMbook("pageSize"), 10);
     }
 
+    private int page;
+
+    private int pageSize;
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
     /**
      * 字符串转目标对象
      *
@@ -38,7 +59,14 @@ public class AdvertisementParams extends BaseParams {
      * @return
      */
     public static AdvertisementParams covertToAdvertisementParams(String message) {
+        byte[] asBytes = Base64.decodeBase64(message);
+        try {
+            message = new String(asBytes, "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
         AdvertisementParams advertisementParams = new AdvertisementParams();
+        advertisementParams.setmBook(message);
         Object object = JSONUtils.JSONToObj(message, AdvertisementParams.class);
         if (object instanceof AdvertisementParams) {
             advertisementParams = (AdvertisementParams) object;

--- a/src/main/java/com/tuan/pagehelper/BaseParams.java
+++ b/src/main/java/com/tuan/pagehelper/BaseParams.java
@@ -20,6 +20,7 @@ public class BaseParams {
         this.mBook = mBook;
     }
 
+
     /**
      * 解析mbook
      *

--- a/src/main/resources/mappers/AdvertisementMapper.xml
+++ b/src/main/resources/mappers/AdvertisementMapper.xml
@@ -110,5 +110,12 @@
         <if test="weight != null">
             and weight = #{weight,jdbcType=INTEGER}
         </if>
+        <include refid="fetchLimitClause"/>
     </select>
+    <!-- fetch limit子句-->
+    <sql id="fetchLimitClause">
+        <if test="page != null and page >= 0 and pageSize != null and pageSize > 0">
+            LIMIT #{page}, #{pageSize}
+        </if>
+    </sql>
 </mapper>


### PR DESCRIPTION
怎么完善的呢：
第一：之前的只是传回了JSON的字符串，其实很不友好，因为解析的时候难免会有问题。
 所以这个时候我选择了base64编码进行返回前的编码，再当前端回传的时候我再进行base64解码。
第二：完善了之前的一些bug，确实昨天不太开心，很难写代码。
第三：其实这个MBOOK是一种机制，比如当你有些东西需要自己控制，想要把之前查询的一些东西作为下次查询的条件，这个参数是非常不错的选择。
第四：增加了查询的页码、个数的限制。